### PR TITLE
Fixed closing of the file handle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: caTools
 Type: Package
 Title: Tools: Moving Window Statistics, GIF, Base64, ROC AUC, etc
-Version: 1.18.2
-Date: 2021-03-26
+Version: 1.18.3
+Date: 2023-12-06
 Author: Jarek Tuszynski <jaroslaw.w.tuszynski@saic.com>
 Maintainer: Michael Dietze <mdietze@gfz-potsdam.de>
 Depends: R (>= 3.6.0)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 Changes for R-package caTools
 
+Version 0.1.18.3 (2023-12-06)
+ - fixed bug where imgreadGif does not close file handle
+
 Version 0.1.18.0 (2020-01-15)
  - maintainer change
  - fix of CRAN test issues (C routine registration, 1, 2)

--- a/src/GifTools.cpp
+++ b/src/GifTools.cpp
@@ -574,13 +574,13 @@ int imreadGif(const char* filename, int nImage, bool verbose,
   //====================================================
   // GIF Signature, Screen Descriptor & Global Color Map
   //====================================================
-  if (!fread(version, 6, 1, fp)) return -2;    // Read Header
+  if (!fread(version, 6, 1, fp)) { fclose(fp); return -2; }    // Read Header
   version[6] = '\0';
-  if ((strcmp(version, "GIF87a") != 0) && (strcmp(version, "GIF89a") != 0)) return -2;
-  if (!fread(buffer, 7, 1, fp)) return -3;     // Read Screen Descriptor
+  if ((strcmp(version, "GIF87a") != 0) && (strcmp(version, "GIF89a") != 0)) { fclose(fp); return -2; }
+  if (!fread(buffer, 7, 1, fp)) { fclose(fp); return -3; }     // Read Screen Descriptor
   if(verbose) print("GIF image header\n");
   i = ReadColorMap(fp, buffer[4], ColorMap);   // Read Global Colormap
-  if (i==0) return -3;
+  if (i==0) { fclose(fp); return -3; }
   if (i==2) nColMap++;
   if(verbose) {
     if(i==2) print("Global colormap with %i colors \n", 2<<(buffer[4]&0x07));
@@ -705,6 +705,7 @@ int imreadGif(const char* filename, int nImage, bool verbose,
     }
   } // end while
   if(verbose) print("\n");
+  fclose(fp);
   *Comment = comment;
   *data = cube;
   nRow  = Height;


### PR DESCRIPTION
Close files to prevent leaking file handles (mostly becomes a problem when many files are processed within one R session).